### PR TITLE
Clarify VVVVVV stack memory layout is 2.2 and below

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a python based autosplitting tool for speedrunning. Currently only Linux
 
 ## Why was this done?
 
-While LiveSplit does work inside wine, the autosplit component does not work on linux machines. In addition to this, it is not possible to create breakpoints and read values in CPU registers with the autosplit component of LiveSplit. PyAutoSplit can do that. This is especially useful in a game like VVVVVV, where all relevant information are on the stack, and therefore at nonstatic locations in memory. 
+While LiveSplit does work inside wine, the autosplit component does not work on linux machines. In addition to this, it is not possible to create breakpoints and read values in CPU registers with the autosplit component of LiveSplit. PyAutoSplit can do that. This is especially useful in a game like VVVVVV (2.2 and below), where all relevant information are on the stack, and therefore at nonstatic locations in memory. 
 
 Current strategies involve scanning the processes memory for specific values, to guess the location of information like gamestate etc. Unfortunately this is rather error prone. With PyAutoSplit one can set a breakpoint at the (static) instruction where the game object is created, and read the cpu registers to get an exact location of the game object.
 


### PR DESCRIPTION
It's only in VVVVVV 2.2 and below that critical information is put on the stack, and has memory addresses that are not fixed. In 2.3, all global classes got moved off of the stack and onto the static memory region (not the heap), so everything now has a fixed memory address that can be trivially obtained directly from the binary. (This also got rid of having to pass all the global classes around in arguments, and fixed a potential stack overflow on Windows due to Windows's small stack size. Moving everything off the stack is a really good thing all around.)

So, clarify this in the README, so people who look at VVVVVV for themselves after reading the README don't get confused about the memory layout (since it changed in 2.3).