### PR TITLE
Fix Python version to be 3.9 in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "Topic :: Games/Entertainment",
         "Topic :: Software Development :: Debuggers",
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.9',
     entry_points = {
         'console_scripts': ['pyautosplit=pyautosplit.main:main']
     }


### PR DESCRIPTION
Due to the use of `list[Any]` in `game.py`, PyAutoSplit only works with Python versions 3.9 or later.