### PR TITLE
Allow tracking wine executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install --user git+https://github.com/christofsteel/pyautosplit.git
 
 ## Usage
 
-PyAutoSplit has three different _front-ends_: _console out_, _LiveSplit_ and _LiveSplit One_. You select one or multiple front-end with the `-f`/`--front-end` flag. If no front-end flag is given, _LiveSplit_ is automatically selected.
+PyAutoSplit has three different _front-ends_: _console out_, _LiveSplit_ and _LiveSplit One_. You select one or multiple front-end with the `-f`/`--front-ends` flag. If no front-end flag is given, _LiveSplit_ is automatically selected.
 
 ### LiveSplit
 
@@ -58,6 +58,7 @@ A game file is a json file with the following fields:
   * `name`, the name of the game
   * `command`, the launch command to run the game
   * `cwd`, the working directory of the command (optional)
+  * `env`, additional environment variables for the command (optional)
   * `frequency`, how many times a second should the memory be read
   * `time`, how does one calculate the ingame time in seconds (optional). If not present, realtime will be used.
   * `variables`, variables, that can be used to define other components (see below)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A game file is a json file with the following fields:
   * `command`, the launch command to run the game
   * `cwd`, the working directory of the command (optional)
   * `env`, additional environment variables for the command (optional)
+  * `exe`, executable to track (optional, requires wrapper binary, see [wrapper](https://github.com/christofsteel/pyautosplit/tree/main/wrapper#wrapper))
   * `frequency`, how many times a second should the memory be read
   * `time`, how does one calculate the ingame time in seconds (optional). If not present, realtime will be used.
   * `variables`, variables, that can be used to define other components (see below)

--- a/pyautosplit/game.py
+++ b/pyautosplit/game.py
@@ -65,9 +65,13 @@ class Game:
         else:
             cwd = None
 
+        env = os.environ.copy()
+        if "env" in self.data:
+            env = env | self.data["env"]
+
         command = shlex.split(self.data["command"])
         command[0] = Path(command[0]).expanduser()
-        self.process = GameProcess(command, cwd)
+        self.process = GameProcess(command, cwd, env=env)
 
         self.breakpoints = {}
 

--- a/pyautosplit/game.py
+++ b/pyautosplit/game.py
@@ -1,3 +1,4 @@
+import os
 import time
 import shlex
 import sys
@@ -46,7 +47,8 @@ class Route:
 
 
 class Game:
-    def __init__(self, gamedata, rundata, callback_handlers):
+    def __init__(self, gamedata, rundata, callback_handlers,
+                 from_wrapper=False):
         self.data = gamedata
 
         if 'overwrites' in rundata:
@@ -69,9 +71,13 @@ class Game:
         if "env" in self.data:
             env = env | self.data["env"]
 
+        exe = None
+        if from_wrapper is True and "exe" in self.data:
+            exe = self.data["exe"]
+
         command = shlex.split(self.data["command"])
         command[0] = Path(command[0]).expanduser()
-        self.process = GameProcess(command, cwd, env=env)
+        self.process = GameProcess(command, cwd, env=env, exe=exe)
 
         self.breakpoints = {}
 

--- a/pyautosplit/main.py
+++ b/pyautosplit/main.py
@@ -1,6 +1,7 @@
 import json
 import os.path
 from argparse import ArgumentParser
+from argparse import SUPPRESS
 from collections import OrderedDict
 
 from .game import Game
@@ -24,6 +25,8 @@ def main():
     parser.add_argument("--livesplitone-port", type=int, default=5000,
                         help="Bind the livesplitone websocket server to this "
                         "port (default 5000)")
+    parser.add_argument("--from-wrapper", action='store_true', default=False,
+                        help=SUPPRESS)
     parser.add_argument("runfile")
 
     args = parser.parse_args()
@@ -51,7 +54,7 @@ def main():
         callback_handlers.append(
             LiveSplitServer(args.livesplit_host, args.livesplit_port))
 
-    game = Game(gamedata, rundata, callback_handlers)
+    game = Game(gamedata, rundata, callback_handlers, args.from_wrapper)
     game.hook()
 
 

--- a/pyautosplit/process.py
+++ b/pyautosplit/process.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from signal import SIGTRAP
@@ -7,10 +8,11 @@ from ptrace.debugger.process_error import ProcessError
 
 
 class GameProcess:
-    def __init__(self, command, cwd):
+    def __init__(self, command, cwd, env=os.environ.copy()):
         self.process = subprocess.Popen(command,
                                         stdout=subprocess.DEVNULL,
-                                        cwd=cwd)
+                                        cwd=cwd,
+                                        env=env)
 
         self.debugger = ptrace.debugger.PtraceDebugger()
         self.dprocess = self.debugger.addProcess(self.process.pid, False)

--- a/wrapper/README.md
+++ b/wrapper/README.md
@@ -1,0 +1,51 @@
+# Wrapper
+
+Tracking wine games is difficult because wine spawns it's own subprocesses and PyAutoSplit isn't directly allowed to track them.
+As a workaround there's a little wrapper binary which allows to track abritary executables with elevated user rights.
+
+Make sure that the pyautosplit script and all related scripts like python-ptrace **can't be altered** by something malicious. This script will have **elevated user rights** and will be able to **read all memory**. One way to ensure this is by installing PyAutoSplit system-wide.
+
+## Build and install the wrapper binary
+
+1. Install developement dependency equivalents for your distribution:
+    * [`meson`](https://repology.org/project/meson/versions)
+    * [`ninja`](https://repology.org/project/ninja/versions)
+    * [`python`](https://repology.org/project/python/versions)
+    * C compiler like [`gcc`](https://repology.org/project/gcc/versions)
+1. Build the wrapper binary:
+    1.  Create a new directory for building:
+
+        ~~~ sh
+        meson setup builddir --buildtype release
+        ~~~
+    1.  Optional:
+        * Configure the absolute path to PyAutoSplit. The default is `/usr/local/bin/pyautosplit` where PyAutoSplit gets installed system-wide by default and can't be altered without root permissions.
+
+          ~~~ sh
+          meson configure builddir -Dpyautosplit='/usr/local/bin/pyautosplit'
+          ~~~
+    1.  Compile the binary:
+
+        ~~~ sh
+        meson compile -C builddir
+        ~~~
+    1.  Install the binary. The default is `/usr/local/bin/pyautosplit-wrapper` which can't be altered without root permissions.
+
+        ~~~ sh
+        meson install -C builddir
+        ~~~
+1.  Allow this specific binary to read memory from all processes. This requires root privileges.
+    ~~~ sh
+    setcap cap_sys_ptrace=ep /usr/local/bin/pyautosplit-wrapper
+    ~~~
+
+## Configure
+
+Set the executable name in your `gamefile.json`. The name should match the executable exactly.
+
+## Run
+
+Start PyAutoSplit as usual but replace `pyautosplit` with `pyautosplit-wrapper`:
+~~~ sh
+pyautosplit-wrapper -f livesplitone -- routefile.json
+~~~

--- a/wrapper/meson.build
+++ b/wrapper/meson.build
@@ -1,0 +1,11 @@
+project('pyautosplit-wrapper', 'c')
+
+executable(
+    'pyautosplit-wrapper',
+    'pyautosplit-wrapper.c',
+    dependencies: [
+        dependency('python3-embed'),
+    ],
+    c_args: '-DSCRIPT="' + get_option('pyautosplit') + '"',
+    install: true,
+)

--- a/wrapper/meson_options.txt
+++ b/wrapper/meson_options.txt
@@ -1,0 +1,1 @@
+option('pyautosplit', type: 'string', value: '/usr/local/bin/pyautosplit', description: 'Path to PyAutoSplit')

--- a/wrapper/pyautosplit-wrapper.c
+++ b/wrapper/pyautosplit-wrapper.c
@@ -1,0 +1,52 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#ifndef SCRIPT
+    #define SCRIPT "/usr/local/bin/pyautosplit"
+#endif
+
+// https://docs.python.org/3/extending/embedding.html
+int main(int argc, char *argv[])
+{
+    // Python requires wide chars
+    int wargc = argc + 1;
+    wchar_t *wargv[wargc];
+
+    // replace this wrapper with the PyAutoSplit
+    wargv[0] = Py_DecodeLocale(SCRIPT, NULL);
+    wargv[1] = Py_DecodeLocale("--from-wrapper", NULL);
+    if(wargv[0] == NULL || wargv[1] == NULL)
+    {
+        return EXIT_FAILURE;
+    }
+
+    // convert remaining arguments to wide chars
+    for (int i = 1; i < argc; i++)
+    {
+        wargv[i+1] = Py_DecodeLocale(argv[i], NULL);
+        if(wargv[i+1] == NULL)
+        {
+            return EXIT_FAILURE;
+        }
+    }
+
+    // initialize embedded python interpreter
+    Py_SetProgramName(wargv[0]);
+    Py_Initialize();
+    PySys_SetArgv(wargc, wargv);
+
+    // open and run PyAutoSplit with embedded
+    // Python interpreter
+    FILE *file = fopen(SCRIPT, "r");
+    PyRun_SimpleFile(file, "pyautosplit");
+
+    // cleanup
+    if (Py_FinalizeEx() < 0)
+    {
+        exit(120);
+    }
+
+    PyMem_RawFree(wargv[0]);
+
+    return 0;
+}


### PR DESCRIPTION
Tracking wine processes seems not possible in the current state because of the way wine spawns the executable.

This PR allows to track wine (or any other executable) by providing an optional wrapper binary which then gets the capability `cap_sys_ptrace=ep` and allows execution without root privileges. While this would be possible without the wrapper it would be necessary to give `python` this capability - making essentially all memory accessible to all python scripts. While this is probably a security issue for whole `python` I hope to limit the security issue with this wrapper and by making it very clear in the readme that this wrapper and dependent scripts (`pyautosplit`, `python-ptrace`, …) should be secured against malicious activity.

To know wether PyAutoSplit is called by the wrapper I've added a silent argument `--from-wrapper`. Together with an `exe` in the game json the script goes into the "wrapper" mode and attaches to the pid of the given executable instead of the direct child process.

While at it I also added the possibility to add environment variables in the game json (like `WINEPREFIX=/path/asd`):
~~~ json
"env": {
	"WINEPREFIX": "/path/asd"
}
~~~