### PR TITLE
callbacks: reset timer before starting LiveSplitOne timer

### DIFF
--- a/pyautosplit/callbacks.py
+++ b/pyautosplit/callbacks.py
@@ -192,6 +192,8 @@ class LiveSplitOne(CallbackHandler):
         self._send_command("reset")
 
     def start(self):
+        # LiveSplitOne can fail to start to timer if the timer had already been started. (ex. after a pause)
+        self.reset()
         self._send_command("start")
 
     def split(self, split):


### PR DESCRIPTION
When the timer is not reset, the start command can fail to actually start the timer. This PR makes it so a reset command is issued before starting the timer.